### PR TITLE
UI-89 - Customize Modal to make the cancel button optional

### DIFF
--- a/src/Component/Modal/index.js
+++ b/src/Component/Modal/index.js
@@ -23,9 +23,9 @@ export default function Modal({
             </div>
 
             <div className="actions">
-                <SecondaryButton onClick={onCancel}>
+                {onCancel && <SecondaryButton onClick={onCancel}>
                     Cancel
-                </SecondaryButton>
+                </SecondaryButton>}
 
                 {action}
             </div>


### PR DESCRIPTION
Make the cancel button optional. It's probably worth to remove it completely but it requires to fix a lot of existing modals.