### PR TITLE
UI-92 Unable to input/type hex code in ColorPicker

### DIFF
--- a/src/Component/ColorPicker/Util/formatColor.js
+++ b/src/Component/ColorPicker/Util/formatColor.js
@@ -1,0 +1,10 @@
+import hexFormat from './hexFormat';
+import rgbFormat from './rgbFormat';
+
+export default function formatColor(color, isRgbFormat) {
+    if (isRgbFormat) {
+        return rgbFormat(color);
+    }
+
+    return hexFormat(color);
+}

--- a/src/Component/ColorPicker/Util/hexFormat.js
+++ b/src/Component/ColorPicker/Util/hexFormat.js
@@ -1,0 +1,10 @@
+import {colord} from 'colord';
+
+import isHex from './isHex';
+
+export default function hexFormat(color) {
+    return isHex(color)
+        ? color
+        : colord(color).toHex()
+    ;
+}

--- a/src/Component/ColorPicker/Util/isHex.js
+++ b/src/Component/ColorPicker/Util/isHex.js
@@ -1,0 +1,4 @@
+export default function isHex(color) {
+    return color.startsWith('#');
+}
+

--- a/src/Component/ColorPicker/Util/isRgb.js
+++ b/src/Component/ColorPicker/Util/isRgb.js
@@ -1,0 +1,4 @@
+export default function isRgb(color) {
+    return color.startsWith('rgb');
+}
+

--- a/src/Component/ColorPicker/Util/parseColor.js
+++ b/src/Component/ColorPicker/Util/parseColor.js
@@ -1,0 +1,12 @@
+export const REGEX_HEX_PATTERN = /#(([0-9a-fA-F]{2}){3,4})/g;
+export const REGEX_RGB_PATTERN = /rgb\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*\)/g;
+export const REGEX_RGBA_PATTERN = /rgba\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d)\s*,?\s*([0]\.?\d*?|1)\)/g;
+
+export default function parseColor(color, regexPattern) {
+    const match = color.match(regexPattern);
+    const isValidColor = match?.length === 1 && match[0] === color;
+    return isValidColor
+        ? color
+        : ''
+    ;
+}

--- a/src/Component/ColorPicker/Util/parseHexColor.js
+++ b/src/Component/ColorPicker/Util/parseHexColor.js
@@ -1,0 +1,5 @@
+import parseColor, {REGEX_HEX_PATTERN} from './parseColor';
+
+export default function parseHexColor(color) {
+    return parseColor(color, REGEX_HEX_PATTERN);
+}

--- a/src/Component/ColorPicker/Util/parseInputColor.js
+++ b/src/Component/ColorPicker/Util/parseInputColor.js
@@ -1,0 +1,9 @@
+import parseHexColor from './parseHexColor';
+import parseRgbColor from './parseRgbColor';
+
+export default function parseInputColor(color, isRgbFormat) {
+    return isRgbFormat
+        ? parseRgbColor(color)
+        : parseHexColor(color)
+    ;
+}

--- a/src/Component/ColorPicker/Util/parseRgbColor.js
+++ b/src/Component/ColorPicker/Util/parseRgbColor.js
@@ -1,0 +1,9 @@
+import parseColor, {REGEX_RGB_PATTERN, REGEX_RGBA_PATTERN} from './parseColor';
+
+export default function parseRgbColor(color) {
+    const result = parseColor(color, REGEX_RGB_PATTERN)
+    return result
+        ? result
+        : parseColor(color, REGEX_RGBA_PATTERN)
+    ;
+}

--- a/src/Component/ColorPicker/Util/rgbFormat.js
+++ b/src/Component/ColorPicker/Util/rgbFormat.js
@@ -1,0 +1,11 @@
+import {colord} from 'colord';
+
+import isRgb from './isRgb';
+
+export default function rgbFormat(color) {
+    return isRgb(color)
+        ? color
+        : colord(color).toRgbString()
+    ;
+}
+

--- a/src/Component/ColorPicker/index.js
+++ b/src/Component/ColorPicker/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {RgbaStringColorPicker} from 'react-colorful';
 
 import {extend} from 'colord';
@@ -11,29 +11,50 @@ import SecondaryButton from 'Component/Button/Secondary';
 import SimpleInput from 'Component/Input/Simple';
 import Toggle from 'Component/Toggle';
 
-import formatColor from 'Util/formatColor';
-import isRgb from 'Util/isRgb';
-import rgbFormat from 'Util/rgbFormat';
+import formatColor from './Util/formatColor';
+import isRgb from './Util/isRgb';
+import parseInputColor from './Util/parseInputColor';
+import rgbFormat from './Util/rgbFormat';
 
 import './ColorPicker.scss';
 
 export default function ColorPicker(props) {
     const [rgbColor, setRgbColor] = useState('');
+    const [colorInput, setColorInput] = useState('');
     const [isRgbFormat, setIsRgbFormat] = useState(false);
+    const inputError = useRef(false);
 
     useEffect(() => {
         if (!props.color) return;
 
-        setFormattedRgbColor(props.color);
-        setIsRgbFormat(
-            isRgb(props.color)
-        );
+        const isRgbType = isRgb(props.color);
+        setRgbColor(rgbFormat(props.color));
+        setColorInput(formatColor(props.color, isRgbType))
+        setIsRgbFormat(isRgbType);
     }, [props.color]);
 
-    function setFormattedRgbColor(color) {
-        setRgbColor(
-            rgbFormat(color)
-        );
+    function updateRgbToggle(rgbModeOn) {
+        setIsRgbFormat(rgbModeOn);
+        setColorInput(formatColor(rgbColor, rgbModeOn));
+    }
+
+    function updateSelectedColor(color) {
+        setColorInput(format(color));
+        setRgbColor(rgbFormat(color));
+    }
+
+    function updateColorInput(color) {
+        const validColor = parseInputColor(color, isRgbFormat);
+
+        if (validColor) {
+            inputError.current = false;
+            updateSelectedColor(validColor);
+
+            return;
+        }
+
+        inputError.current = true;
+        setColorInput(color);
     }
 
     function format(color) {
@@ -46,26 +67,27 @@ export default function ColorPicker(props) {
 
     function onSelect() {
         props.onSelect(
-            formatColor(rgbColor)
+            format(rgbColor)
         );
     }
 
     return <color-picker>
         <RgbaStringColorPicker
             color={rgbColor}
-            onChange={setRgbColor}
+            onChange={updateSelectedColor}
         />
 
         <SimpleInput
-            onChange={setFormattedRgbColor}
+            onChange={updateColorInput}
             scalable
-            value={format(rgbColor)}
+            value={colorInput}
+            error={inputError.current}
         />
 
         <div className="actions">
             <toggle-with-label>
                 <Toggle
-                    onChange={setIsRgbFormat}
+                    onChange={updateRgbToggle}
                     value={isRgbFormat}
                 />
 
@@ -82,6 +104,7 @@ export default function ColorPicker(props) {
                 <PrimaryButton
                     onClick={onSelect}
                     size="large"
+                    disabled={inputError.current}
                 >
                     Select
                 </PrimaryButton>

--- a/src/Component/ColorPicker/index.js
+++ b/src/Component/ColorPicker/index.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {RgbaStringColorPicker} from 'react-colorful';
 
-import {colord, extend} from 'colord';
+import {extend} from 'colord';
 import namesPlugin from 'colord/plugins/names';
 // Using CSS color names plugin for Colord
 extend([namesPlugin]);
@@ -10,6 +10,10 @@ import PrimaryButton from 'Component/Button/Primary';
 import SecondaryButton from 'Component/Button/Secondary';
 import SimpleInput from 'Component/Input/Simple';
 import Toggle from 'Component/Toggle';
+
+import formatColor from 'Util/formatColor';
+import isRgb from 'Util/isRgb';
+import rgbFormat from 'Util/rgbFormat';
 
 import './ColorPicker.scss';
 
@@ -32,34 +36,8 @@ export default function ColorPicker(props) {
         );
     }
 
-    function isHex(color) {
-        return color.startsWith('#');
-    }
-
-    function hexFormat(color) {
-        return isHex(color)
-            ? color
-            : colord(color).toHex()
-        ;
-    }
-
-    function isRgb(color) {
-        return color.startsWith('rgb');
-    }
-
-    function rgbFormat(color) {
-        return isRgb(color)
-            ? color
-            : colord(color).toRgbString()
-        ;
-    }
-
-    function formatColor(color) {
-        if (isRgbFormat) {
-            return rgbFormat(color);
-        }
-
-        return hexFormat(color);
+    function format(color) {
+        return formatColor(color, isRgbFormat);
     }
 
     function onClear() {
@@ -81,7 +59,7 @@ export default function ColorPicker(props) {
         <SimpleInput
             onChange={setFormattedRgbColor}
             scalable
-            value={formatColor(rgbColor)}
+            value={format(rgbColor)}
         />
 
         <div className="actions">


### PR DESCRIPTION
Little  rework of ColorPicket to avoid auto format for input field. The idea is to parse color first and block submit button instead of replacing input field with #000000 when input is not valid.